### PR TITLE
Update repository urls.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,11 +2,14 @@
   "name": "unc-path-regex",
   "description": "Regular expression for testing if a file path is a windows UNC file path. Can also be used as a component of another regexp via the `.source` property.",
   "version": "0.1.1",
-  "homepage": "https://github.com/jonschlinkert/unc-path-regex",
+  "homepage": "https://github.com/regexhq/unc-path-regex",
   "author": "Jon Schlinkert (https://github.com/jonschlinkert)",
-  "repository": "jonschlinkert/unc-path-regex",
+  "repository": {
+    "type" : "git",
+    "url": "https://github.com/regexhq/unc-path-regex.git"
+  },
   "bugs": {
-    "url": "https://github.com/jonschlinkert/unc-path-regex/issues"
+    "url": "https://github.com/regexhq/unc-path-regex/issues"
   },
   "license": "MIT",
   "files": [


### PR DESCRIPTION
To make automated tools work with npmjs.com metadata, you needto updateyour package.json file to reflect the current github repository move to the regexhq organization.

Could you please update those urls and make a release, so that creating webjars for unc-path-regex can be automated ?

(see http://webjars.org for more info about that packaging format)
